### PR TITLE
Fix compilation issue on Beaglebone Black

### DIFF
--- a/src/gpiowatcher.cc
+++ b/src/gpiowatcher.cc
@@ -4,6 +4,8 @@
 #include <string>
 #include <node.h>
 #include <node_version.h>
+#include <sys/types.h> 
+#include <unistd.h>
 
 /*
  * This Node.js addon can be used to detect interrupts on GPIO inputs.


### PR DESCRIPTION
Fixing these compilation errors:

```
../src/gpiowatcher.cc: In function 'void WatchWork(uv_work_t*)':
../src/gpiowatcher.cc:117:53: error: 'read' was not declared in this scope
../src/gpiowatcher.cc:133:53: error: 'lseek' was not declared in this scope
../src/gpiowatcher.cc:156:21: error: 'close' was not declared in this scope
```
