### PR TITLE
suggested export of Gpio One / Zero

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ useLed(led, 1);
   * [setActiveLow(invert) - Set GPIO activeLow setting](#setactivelowinvert)
   * [unexport() - Reverse the effect of exporting the GPIO to userspace](#unexport)
   * [static accessible - Determine whether or not GPIO access is possible](#static-accessible)
+  * [HIGH / LOW - Constants exported representing read/write values used](#high-low)
 
 ##### Gpio(gpio, direction [, edge] [, options])
 - gpio - An unsigned integer specifying the GPIO number.
@@ -330,6 +331,12 @@ This property is useful for mocking functionality on computers used for
 development that do not provide access to GPIOs.
 
 This is a static property and should be accessed as `Gpio.accessible`.
+
+##### static HIGH / LOW
+The static values of High and Low are exported on the `Gpio` object to provide
+consistent way for consuming application to test against, or use during `write` operations.
+
+These should be used in place of hardcoded `1` and `0` values (as per most lint rules).
 
 ### Synchronous API
 

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ useLed(led, 1);
   * [setActiveLow(invert) - Set GPIO activeLow setting](#setactivelowinvert)
   * [unexport() - Reverse the effect of exporting the GPIO to userspace](#unexport)
   * [static accessible - Determine whether or not GPIO access is possible](#static-accessible)
-  * [HIGH / LOW - Constants exported representing read/write values used](#high-low)
+  * [HIGH / LOW - Constants exported representing read/write values used](#static-high--low)
 
 ##### Gpio(gpio, direction [, edge] [, options])
 - gpio - An unsigned integer specifying the GPIO number.

--- a/onoff.js
+++ b/onoff.js
@@ -270,4 +270,3 @@ Gpio.HIGH = HIGH;
 Gpio.LOW = LOW;
 
 exports.Gpio = Gpio;
-module.exports = { Gpio };

--- a/onoff.js
+++ b/onoff.js
@@ -7,11 +7,11 @@ const Epoll = require('epoll').Epoll;
 const GPIO_ROOT_PATH = '/sys/class/gpio/';
 
 // fs reads return char data
-const ZERO = Buffer.from('0');
-const ONE = Buffer.from('1');
+const LOW_BUF = Buffer.from('0');
+const HIGH_BUF = Buffer.from('1');
 // lib returns numeric data
-const GPIO_ONE = 1;
-const GPIO_ZERO = 0;
+const HIGH = 1;
+const LOW = 0;
 
 class Gpio {
   constructor(gpio, direction, edge, options) {
@@ -77,7 +77,7 @@ class Gpio {
       }
 
       if (!!options.activeLow) {
-        fs.writeFileSync(this._gpioPath + 'active_low', ONE);
+        fs.writeFileSync(this._gpioPath + 'active_low', HIGH_BUF);
       }
     } else {
       // The pin has already been exported, perhaps by onoff itself, perhaps
@@ -105,7 +105,7 @@ class Gpio {
         }
         try {
           fs.writeFileSync(this._gpioPath + 'active_low',
-            !!options.activeLow ? ONE : ZERO
+            !!options.activeLow ? HIGH_BUF : LOW_BUF
           );
         } catch (ignore) {
         }
@@ -124,8 +124,8 @@ class Gpio {
       const pollerEventHandler = (err, fd, events) => {
         const value = this.readSync();
 
-        if ((value === GPIO_ZERO && this._fallingEnabled) ||
-            (value === GPIO_ONE && this._risingEnabled)) {
+        if ((value === HIGH && this._fallingEnabled) ||
+            (value === LOW && this._risingEnabled)) {
           this._listeners.slice(0).forEach((callback) => {
             callback(err, value);
           });
@@ -159,23 +159,23 @@ class Gpio {
           return callback(err);
         }
 
-        callback(null, buf[0] === ONE[0] ? GPIO_ONE : GPIO_ZERO);
+        callback(null, buf[0] === HIGH_BUF[0] ? HIGH : LOW);
       }
     });
   }
 
   readSync() {
     fs.readSync(this._valueFd, this._readBuffer, 0, 1, 0);
-    return this._readBuffer[0] === ONE[0] ? GPIO_ONE : GPIO_ZERO;
+    return this._readBuffer[0] === HIGH_BUF[0] ? HIGH : LOW;
   }
 
   write(value, callback) {
-    const writeBuffer = value === GPIO_ONE ? ONE : ZERO;
+    const writeBuffer = value === HIGH ? HIGH_BUF : LOW_BUF;
     fs.write(this._valueFd, writeBuffer, 0, writeBuffer.length, 0, callback);
   }
 
   writeSync(value) {
-    const writeBuffer = value === GPIO_ONE ? ONE : ZERO;
+    const writeBuffer = value === HIGH ? HIGH_BUF : LOW_BUF;
     fs.writeSync(this._valueFd, writeBuffer, 0, writeBuffer.length, 0);
   }
 
@@ -228,11 +228,11 @@ class Gpio {
 
   activeLow() {
     return fs.readFileSync(
-      this._gpioPath + 'active_low')[0] === ONE[0] ? true : false;
+      this._gpioPath + 'active_low')[0] === HIGH_BUF[0] ? true : false;
   }
 
   setActiveLow(invert) {
-    fs.writeFileSync(this._gpioPath + 'active_low', !!invert ? ONE : ZERO);
+    fs.writeFileSync(this._gpioPath + 'active_low', !!invert ? HIGH_BUF : LOW_BUF);
   }
 
   unexport() {
@@ -247,5 +247,8 @@ class Gpio {
   }
 }
 
+Gpio.HIGH = HIGH;
+Gpio.LOW = LOW;
+
 exports.Gpio = Gpio;
-module.exports = { Gpio, GPIO_ONE, GPIO_ZERO };
+module.exports = { Gpio };

--- a/onoff.js
+++ b/onoff.js
@@ -124,8 +124,8 @@ class Gpio {
       const pollerEventHandler = (err, fd, events) => {
         const value = this.readSync();
 
-        if ((value === HIGH && this._fallingEnabled) ||
-            (value === LOW && this._risingEnabled)) {
+        if ((value === LOW && this._fallingEnabled) ||
+            (value === HIGH && this._risingEnabled)) {
           this._listeners.slice(0).forEach((callback) => {
             callback(err, value);
           });


### PR DESCRIPTION
Export the Gpio values returned by library such that external code does not hardcode 1 or 0. (or get confused between using 1 and "1" etc)

this also makes eslint happy