### PR TITLE
guard for non HIGH LOW values

### DIFF
--- a/onoff.js
+++ b/onoff.js
@@ -171,11 +171,13 @@ class Gpio {
   }
 
   write(value, callback) {
+    if(value !== HIGH && value !== LOW) { callback(Error('write value must be HIGH or LOW')); }
     const writeBuffer = value === HIGH ? HIGH_BUF : LOW_BUF;
     fs.write(this._valueFd, writeBuffer, 0, writeBuffer.length, 0, callback);
   }
 
   writeSync(value) {
+    if(value !== HIGH && value !== LOW) { throw Error('write value must be HIGH or LOW'); }
     const writeBuffer = value === HIGH ? HIGH_BUF : LOW_BUF;
     fs.writeSync(this._valueFd, writeBuffer, 0, writeBuffer.length, 0);
   }


### PR DESCRIPTION
- not sure if you want to throw Error or something else.
- not sure about timing of next_tick for callback (but it looks like this is correct per rest of code)
- someone please change my error messages :)
- are there other location that should have similar restrictions?
- should it be moved to a validator function (aka i2cbus `checkHighLow`)?
- README updates?

reference #104 