### PR TITLE
epoll note

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,12 @@ The GPIO sysfs interface can also be used for interrupt detection. onoff can
 detect several thousand interrupts per second on both the BeagleBone and the
 Raspberry Pi.
 
+Note that [epoll package](https://github.com/fivdi/epoll) is currently only
+supported for Linux based sysfs systems; resuting in a error similar to:
+
+`Error: Module did not self-register.`
+
+
 ## Configuring Pullup and Pulldown Resistors
 
 As mentioned in section [How Does onoff Work](#how-does-onoff-work) the sysfs


### PR DESCRIPTION
issue #106 exposed dep issues with eopoll on OSX / Windows / etc.

epoll currently is class code currently lives behind (excessive) #ifdef __linux__ guard.

removing the global guard and replacing it with #include specific and class stubs may provide a solution for temporary installation success and error messages on unsupported platforms.

os support for platforms in the epoll package left for another day.
