### PR TITLE
Allow `accessible` to work on OSX

### DIFF
--- a/onoff.js
+++ b/onoff.js
@@ -2,7 +2,6 @@
 
 const fs = require('fs');
 const debounce = require('lodash.debounce');
-const Epoll = require('epoll').Epoll;
 
 const GPIO_ROOT_PATH = '/sys/class/gpio/';
 
@@ -35,6 +34,8 @@ const waitForAccessPermission = (paths) => {
 
 class Gpio {
   constructor(gpio, direction, edge, options) {
+    const Epoll = require('epoll').Epoll;
+
     if (typeof edge === 'object' && !options) {
       options = edge;
       edge = undefined;


### PR DESCRIPTION
Only require Epoll on class instantiation.

I've been using your library for a couple years now, and it's been great using it. Since I develop on OSX, I ended up mocking the library out locally as described [here](https://stackoverflow.com/a/53798371/818073).

After digging in a bit more, it seems as though requiring `epoll` is the culprit, and if we can delay requiring it then we'd be able to use the `accessible` property to determine whether or not we should use a mock on OSX as well (just as described in the README).

Fixes #69
Fixes #106 