### PR TITLE
Refactored "SIGINIT" example handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ button.watch((err, value) => {
 process.on('SIGINT', () => {
   led.unexport();
   button.unexport();
+  process.exit(1)
 });
 ```
 


### PR DESCRIPTION
Hi, it's me again.
This is a short one however! I promise!

Using the current `SIGINT` overwrite the node process is not correctly exiting because the handler is not stopping the process. To do this calling `process.exit()` is necessary.