### PR TITLE
Update onoff.js

### DIFF
--- a/onoff.js
+++ b/onoff.js
@@ -317,7 +317,7 @@ class Gpio {
     let fd;
 
     try {
-      fd = fs.openSync(GPIO_ROOT_PATH + 'export', 'r+');
+      fd = fs.openSync(GPIO_ROOT_PATH + 'export', fs.constants.O_WRONLY);
     } catch(e) {
       // e.code === 'ENOENT' / 'EACCES' are most common
       // though any failure to open will also result in a gpio


### PR DESCRIPTION
hello! the `accessible` detection works by trying to open `/sys/class/gpio/export` in random access mode, but (at least in our kernel) the file needs to be opened in write mode:

![Screenshot from 2021-04-07 13-28-15](https://user-images.githubusercontent.com/1177304/113859389-215be280-97a5-11eb-9347-f028448af8d4.png)

this causes onoff to incorrectly report `accessible = false`.

I see that originally `w` was used but this was changed two years ago as part of https://github.com/fivdi/onoff/commit/614b94f302c02b55f663007c65cd40d1097c1d82#diff-7cee75ac17737a32caecb759c4b47eacb462e34778c4f60d6ae2f0a0904387f9L271-R267, to add coverage testing.

If I understand correctly, the motive of that change is to fail if the file doesn't exist.
This replaces `r+` with `fs.constants.O_WRONLY`, which is like `w` but fails if the file doesn't exist, and should be appropriate for testing as well.